### PR TITLE
Use ld -N and create minimal linker script

### DIFF
--- a/ports/powerpc/Makefile
+++ b/ports/powerpc/Makefile
@@ -25,7 +25,7 @@ CFLAGS += -msoft-float -mno-string -mno-multiple -mno-vsx -mno-altivec -mlittle-
 CFLAGS += -Os
 CFLAGS += -fdata-sections -ffunction-sections
 
-LDFLAGS = -T powerpc.lds
+LDFLAGS = -N -T powerpc.lds
 
 LIBS =
 

--- a/ports/powerpc/head.S
+++ b/ports/powerpc/head.S
@@ -91,8 +91,3 @@ boot_entry:
 	EXCEPTION(0x1400)
 	EXCEPTION(0x1500)
 	EXCEPTION(0x1600)
-
-.global stack
-stack_bottom:
-	.space	0x1000
-stack:

--- a/ports/powerpc/powerpc.lds
+++ b/ports/powerpc/powerpc.lds
@@ -1,15 +1,10 @@
 SECTIONS
 {
- _start = .;
- . = 0;
- .head : {
-  KEEP(*(.head))
- }
-  . = 0x10000;
-  .text : { *(.text) }
-  . = 0x50000;
-  .data : { *(.data) }
-  .bss : { *(.bss) }
-  . = 0x80000; /* ALSO CHANGE THIS IN HEAD.S */
-  .stack : { *(.stack) }
+	. = 0;
+	_start = .;
+	.head : {
+		KEEP(*(.head))
+	}
+
+	. = 0x1700;
 }


### PR DESCRIPTION
We just need to get head.S to the start of the binary, the
rest of our layout can be handled by ld -N.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>