### PR TITLE
Fix typo in head.S

### DIFF
--- a/ports/powerpc/head.S
+++ b/ports/powerpc/head.S
@@ -60,7 +60,7 @@ boot_entry:
 	/* ALSO CHANGE THIS IN powerpc.lds */
 	LOAD_IMM64(%r1, 0x80000 - 0x100)
 	LOAD_IMM64(%r12, main)
-	mtctr	%r12,
+	mtctr	%r12
 	bctrl
 	b .
 


### PR DESCRIPTION
clang/llvm complains about the trailing comma.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>